### PR TITLE
Remov extension usage in the main class of the game module

### DIFF
--- a/game/src/main/java/net/theevilreaper/tamias/Tamias.java
+++ b/game/src/main/java/net/theevilreaper/tamias/Tamias.java
@@ -1,0 +1,20 @@
+package net.theevilreaper.tamias;
+
+import net.minestom.server.MinecraftServer;
+import net.theevilreaper.tamias.game.TamiasGame;
+import net.theevilreaper.tamias.game.util.FileChecker;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class Tamias {
+
+    public static void main(String[] args) {
+        MinecraftServer minecraftServer = new MinecraftServer();
+        Path rootPath = Paths.get("");
+        FileChecker.checkFileIntegrity(rootPath);
+        new TamiasGame(rootPath);
+        minecraftServer.start("localhost", 25565);
+
+    }
+}

--- a/game/src/main/java/net/theevilreaper/tamias/game/TamiasGame.java
+++ b/game/src/main/java/net/theevilreaper/tamias/game/TamiasGame.java
@@ -23,7 +23,6 @@ import net.minestom.server.event.player.PlayerChatEvent;
 import net.minestom.server.event.player.PlayerDisconnectEvent;
 import net.minestom.server.event.player.PlayerSpawnEvent;
 import net.minestom.server.event.player.PlayerUseItemEvent;
-import net.minestom.server.extensions.Extension;
 import net.theevilreaper.tamias.common.ListenerHandling;
 import net.theevilreaper.tamias.common.config.GameConfig;
 import net.theevilreaper.tamias.common.config.GameConfigReader;
@@ -61,10 +60,10 @@ import net.theevilreaper.tamias.game.scoreboard.TamiasScoreboard;
 import net.theevilreaper.tamias.game.stamina.StaminaService;
 import net.theevilreaper.tamias.game.team.TamiasTeamCreator;
 import net.theevilreaper.tamias.game.team.TeamHelper;
-import net.theevilreaper.tamias.game.util.FileChecker;
 import net.theevilreaper.tamias.game.util.Items;
 import org.jetbrains.annotations.NotNull;
 
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +76,7 @@ import java.util.function.Supplier;
  * @version 1.0.0
  * @since 1.0.0
  **/
-public class Tamias extends Extension implements ListenerHandling, MapFilter {
+public final class TamiasGame implements ListenerHandling, MapFilter {
 
     private final LinearPhaseSeries<Phase> phaseSeries;
     private final TeamService<Team> teamService;
@@ -89,8 +88,8 @@ public class Tamias extends Extension implements ListenerHandling, MapFilter {
     private final TamiasScoreboard scoreboard;
     private final MapProvider mapProvider;
 
-    public Tamias() {
-        this.gameConfig = new GameConfigReader(ROOT_FOLDER).getConfig();
+    public TamiasGame(@NotNull Path rootPath) {
+        this.gameConfig = new GameConfigReader(rootPath).getConfig();
         this.phaseSeries = new LinearPhaseSeries<>();
         this.teamService = new TeamServiceImpl<>();
         this.mapProvider = new GameMapProvider();
@@ -100,11 +99,7 @@ public class Tamias extends Extension implements ListenerHandling, MapFilter {
         this.roundProvider = new RoundProvider(this.gameConfig.maxRounds());
         this.scoreboard = TamiasScoreboard.create();
         this.timeUpdater = this.scoreboard::updateTime;
-    }
 
-    @Override
-    public void initialize() {
-        FileChecker.checkFileIntegrity(getDataDirectory());
         registerCancelListener(MinecraftServer.getGlobalEventHandler());
 
         MinecraftServer.getCommandManager().register(new StartCommand(this.phaseSeries::getCurrentPhase));
@@ -115,11 +110,6 @@ public class Tamias extends Extension implements ListenerHandling, MapFilter {
         MinecraftServer.getCommandManager().register(new TestCommand());
         this.phaseSeries.start();
         this.scoreboard.updateMapName("Test");
-    }
-
-    @Override
-    public void terminate() {
-
     }
 
     private void createPhaseStructure() {


### PR DESCRIPTION
Der Pull Request entfernt die Verwendung der Erweiterungsklasse von Minestom in der Hauptklasse des Spielmoduls. Wenn wir unsere Spiele veröffentlichen, erstellen wir ein Docker-Image und die Verwendung eines gebündelten Jars ist einfacher.