### PR TITLE
Overhaul team creation

### DIFF
--- a/common/src/main/java/net/theevilreaper/tamias/common/util/Tags.java
+++ b/common/src/main/java/net/theevilreaper/tamias/common/util/Tags.java
@@ -13,7 +13,7 @@ import java.util.UUID;
  **/
 public final class Tags {
 
-    public static final Tag<Byte> TEAM_ID = Tag.Byte("teamId");
+    public static final Tag<Byte> TEAM_ID = Tag.Transient("teamId");
     public static final Tag<Byte> ITEM_TAG = Tag.Byte("itemTag");
     public static final Tag<UUID> SHOOTER_ID = Tag.UUID("shooter");
 

--- a/game/src/main/java/net/theevilreaper/tamias/game/Tamias.java
+++ b/game/src/main/java/net/theevilreaper/tamias/game/Tamias.java
@@ -2,12 +2,10 @@ package net.theevilreaper.tamias.game;
 
 import de.icevizion.aves.util.functional.PlayerConsumer;
 import de.icevizion.aves.util.functional.VoidConsumer;
-import de.icevizion.xerus.api.ColorData;
 import de.icevizion.xerus.api.phase.CyclicPhaseSeries;
 import de.icevizion.xerus.api.phase.LinearPhaseSeries;
 import de.icevizion.xerus.api.phase.Phase;
 import de.icevizion.xerus.api.team.Team;
-import de.icevizion.xerus.api.team.TeamCreator;
 import de.icevizion.xerus.api.team.TeamService;
 import de.icevizion.xerus.api.team.TeamServiceImpl;
 import de.icevizion.xerus.api.team.event.MultiPlayerTeamEvent;
@@ -59,7 +57,6 @@ import net.theevilreaper.tamias.game.round.RoundConditions;
 import net.theevilreaper.tamias.game.round.RoundProvider;
 import net.theevilreaper.tamias.game.scoreboard.TamiasScoreboard;
 import net.theevilreaper.tamias.game.stamina.StaminaService;
-import net.theevilreaper.tamias.game.team.TamiasTeamCreator;
 import net.theevilreaper.tamias.game.team.TeamHelper;
 import net.theevilreaper.tamias.game.util.FileChecker;
 import net.theevilreaper.tamias.game.util.Items;
@@ -94,7 +91,7 @@ public class Tamias extends Extension implements ListenerHandling, MapFilter {
         this.phaseSeries = new LinearPhaseSeries<>();
         this.teamService = new TeamServiceImpl<>();
         this.mapProvider = new GameMapProvider();
-        this.initTeams();
+        TeamHelper.loadTeams(this.gameConfig.teamSize(), this.teamService);
         this.staminaService = new StaminaService();
         this.items = new Items();
         this.roundProvider = new RoundProvider(this.gameConfig.maxRounds());
@@ -187,19 +184,6 @@ public class Tamias extends Extension implements ListenerHandling, MapFilter {
         gameSeries.setMaxIterations(this.gameConfig.maxRounds());
         this.phaseSeries.add(gameSeries);
         this.phaseSeries.add(new RestartPhase());
-    }
-
-    private void initTeams() {
-        TeamCreator teamCreator = new TamiasTeamCreator();
-        int teamSize = this.gameConfig.teamSize();
-        this.teamService.add(Team.builder(teamCreator)
-                .colorData(ColorData.GREEN).name(GameConfig.SURVIVOR_TEAM_NAME).capacity(teamSize)
-                .build()
-        );
-        this.teamService.add(Team.builder(teamCreator)
-                .colorData(ColorData.RED).name(GameConfig.BOMBER_TEAM).capacity(teamSize)
-                .build()
-        );
     }
 
     public @NotNull Map<Class<? extends Event>, Consumer<? extends Event>> registerGameListener() {

--- a/game/src/main/java/net/theevilreaper/tamias/game/team/TamiasTeamCreator.java
+++ b/game/src/main/java/net/theevilreaper/tamias/game/team/TamiasTeamCreator.java
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.NotNull;
  * @see TeamCreator
  * @since 1.0.0
  */
-public final class TamiasTeamCreator implements TeamCreator {
+final class TamiasTeamCreator implements TeamCreator {
 
     /**
      * Creates a new instance of the {@link TamiasTeam}.

--- a/game/src/main/java/net/theevilreaper/tamias/game/team/TeamHelper.java
+++ b/game/src/main/java/net/theevilreaper/tamias/game/team/TeamHelper.java
@@ -2,7 +2,9 @@ package net.theevilreaper.tamias.game.team;
 
 import de.icevizion.aves.util.Players;
 import de.icevizion.aves.util.functional.PlayerConsumer;
+import de.icevizion.xerus.api.ColorData;
 import de.icevizion.xerus.api.team.Team;
+import de.icevizion.xerus.api.team.TeamCreator;
 import de.icevizion.xerus.api.team.TeamService;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Pos;
@@ -28,6 +30,27 @@ import java.util.function.IntFunction;
  **/
 public final class TeamHelper {
 
+    /**
+     * Loads the teams into the team service.
+     * The survivor team is green and the bomber team is red.
+     *
+     * @param teamSize    the size of each team
+     * @param teamService the service which provides access to the teams
+     */
+    public static void loadTeams(int teamSize, @NotNull TeamService<Team> teamService) {
+        // Avoid loading teams multiple times
+        if (teamService.hasTeams()) return;
+        TeamCreator teamCreator = new TamiasTeamCreator();
+        teamService.add(Team.builder(teamCreator)
+                .colorData(ColorData.GREEN).name(GameConfig.SURVIVOR_TEAM_NAME).capacity(teamSize)
+                .build()
+        );
+        teamService.add(Team.builder(teamCreator)
+                .colorData(ColorData.RED).name(GameConfig.BOMBER_TEAM).capacity(teamSize)
+                .build()
+        );
+    }
+
     public static void switchToTNTTeam(@NotNull IntFunction<Team> teamIntFunction, @NotNull Player player) {
         Check.argCondition(!player.hasTag(Tags.TEAM_ID), "Need a team tag for switching teams");
 
@@ -47,7 +70,7 @@ public final class TeamHelper {
         Check.argCondition(!teamService.hasTeams(), "The team service must contain teams");
 
         final Set<Player> onlinePlayers = new HashSet<>(MinecraftServer.getConnectionManager().getOnlinePlayers());
-       // Check.argCondition(onlinePlayers.size() < 2, "The player list must contain at least two players");
+        // Check.argCondition(onlinePlayers.size() < 2, "The player list must contain at least two players");
 
         final Optional<Player> randomPlayer = Players.getRandomPlayer();
         Check.argCondition(randomPlayer.isEmpty(), "No random player found");
@@ -87,7 +110,7 @@ public final class TeamHelper {
      * @param pos  the position to teleport the players
      */
     private static void teleport(@NotNull Team team, @NotNull Pos pos, @Nullable PlayerConsumer callback) {
-       // Check.argCondition(team.getPlayers().isEmpty(), "The given team can't be empty");
+        // Check.argCondition(team.getPlayers().isEmpty(), "The given team can't be empty");
         team.getPlayers().forEach(player -> {
             player.teleport(pos).join();
             if (callback != null) {


### PR DESCRIPTION
The pull request updates how the game loads the required team reference. The logic has been moved to the `TeamHelper` class, and the custom creator has been adjusted accordingly. This change reduces the main class’s complexity, improving readability and maintainability. Additionally, the `teamId` tag is now transient to prevent serialization over the network.