### PR TITLE
Overhaul map provider in the game module

### DIFF
--- a/game/src/main/java/net/theevilreaper/tamias/game/Tamias.java
+++ b/game/src/main/java/net/theevilreaper/tamias/game/Tamias.java
@@ -142,10 +142,7 @@ public class Tamias implements ListenerHandling {
                 this.gameConfig.lobbyTime()
         ));
         CyclicPhaseSeries<Phase> gameSeries = new CyclicPhaseSeries<>("game");
-        Consumer<List<Player>> teleportConsumer = players -> gameMapProvider.teleportPlayers(players, this.roundProvider::isFirstRound);
         gameSeries.add(new MapBuildPhase(
-                gameMapProvider::switchInstanceHolding,
-                teleportConsumer,
                 () -> {
                     return null;
                 }
@@ -159,8 +156,6 @@ public class Tamias implements ListenerHandling {
 
         gameSeries.add(new PrePlayingPhase(
                 this.teamService,
-                gameMapProvider::getActiveMap,
-                gamePreparation,
                 this.items::setItemToPlayer,
                 () -> staminaService.createStaminaObjects(this.teamService)
         ));
@@ -170,7 +165,6 @@ public class Tamias implements ListenerHandling {
                 AttributeHelper.enableMovement(player);
                 this.scoreboard.addViewer(player);
             }
-            gameMapProvider.resetSpawnArea();
             this.staminaService.start();
         };
 
@@ -186,8 +180,7 @@ public class Tamias implements ListenerHandling {
                 new PostPlayingPhase(
                         this.roundProvider::isLastRound,
                         this.roundProvider::triggerNextRound,
-                        () -> {},
-                        teleportConsumer
+                        () -> {}
                 )
         );
         gameSeries.setMaxIterations(this.gameConfig.maxRounds());

--- a/game/src/main/java/net/theevilreaper/tamias/game/map/GameMapProvider.java
+++ b/game/src/main/java/net/theevilreaper/tamias/game/map/GameMapProvider.java
@@ -16,10 +16,19 @@ import org.jetbrains.annotations.NotNull;
 import java.nio.file.Path;
 import java.util.Optional;
 
+/**
+ * The {@link GameMapProvider} is responsible for the management of the instance which is required for the game.
+ * It holds also a reference to the active map and provides some additional methods.
+ *
+ * @author theEvilReaper
+ * @version 1.0.0
+ * @since 0.1.0
+ */
 public final class GameMapProvider extends AbstractMapProvider implements MapFilter {
 
     /**
-     * Creates a new instance from the provider with teh given parameters.
+     * Creates a new instance from the provider with the given parameters.
+     *
      * @param path the path to the map files
      */
     public GameMapProvider(@NotNull Path path) {
@@ -39,11 +48,20 @@ public final class GameMapProvider extends AbstractMapProvider implements MapFil
         MinecraftServer.getInstanceManager().registerInstance(this.activeInstance);
     }
 
+    /**
+     * Loads the chunks of the active map to ensure that the players can spawn without issues.
+     */
     public void loadGameChunks() {
         GameMap givenMap = (GameMap) this.activeMap;
         this.activeInstance.loadChunk(givenMap.getSpawn()).join();
     }
 
+    /**
+     * Teleports the player to the spawn of the active map.
+     *
+     * @param player      the player to teleport
+     * @param instanceSet if the instance should be set for the player
+     */
     @Override
     public void teleportToSpawn(@NotNull Player player, boolean instanceSet) {
         if (instanceSet) {
@@ -53,6 +71,14 @@ public final class GameMapProvider extends AbstractMapProvider implements MapFil
         player.teleport(this.activeMap.getSpawn());
     }
 
+    /**
+     * Saves the map to the given path.
+     * This method is not supported in the game context, as maps are not saved during gameplay.
+     *
+     * @param path     the path where the map should be saved
+     * @param baseMap  the map to save
+     * @throws UnsupportedOperationException if called
+     */
     @Override
     public void saveMap(@NotNull Path path, @NotNull BaseMap baseMap) {
         throw new UnsupportedOperationException("A game can't save a map");

--- a/game/src/main/java/net/theevilreaper/tamias/game/map/GameMapProvider.java
+++ b/game/src/main/java/net/theevilreaper/tamias/game/map/GameMapProvider.java
@@ -2,128 +2,54 @@ package net.theevilreaper.tamias.game.map;
 
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.entity.Player;
-import net.minestom.server.instance.InstanceContainer;
-import net.minestom.server.timer.Task;
 import net.minestom.server.utils.validate.Check;
 import net.theevilreaper.aves.file.GsonFileHandler;
 import net.theevilreaper.aves.map.BaseMap;
 import net.theevilreaper.aves.map.MapEntry;
 import net.theevilreaper.aves.map.provider.AbstractMapProvider;
-import net.theevilreaper.tamias.common.area.GameArea;
-import net.theevilreaper.tamias.common.area.SpawnArea;
 import net.theevilreaper.tamias.common.explosion.ExplosionCreator;
 import net.theevilreaper.tamias.common.gson.GsonUtil;
 import net.theevilreaper.tamias.common.map.GameMap;
-import net.theevilreaper.tamias.common.map.functional.LobbyMapPredicate;
 import net.theevilreaper.tamias.common.util.MapFilter;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Optional;
-import java.util.Random;
-import java.util.function.BooleanSupplier;
 
 public final class GameMapProvider extends AbstractMapProvider implements MapFilter {
 
-    private final BaseMap lobbyMap;
-    private final BaseMap gameMap;
-
-    private InstanceContainer gameMapInstance;
-
-    private SpawnArea spawnArea;
-    private GameArea gameArea;
-
+    /**
+     * Creates a new instance from the provider with teh given parameters.
+     * @param path the path to the map files
+     */
     public GameMapProvider(@NotNull Path path) {
         super(new GsonFileHandler(GsonUtil.GSON), MapFilter::filterMapsForGame);
         this.mapEntries = this.loadMapEntries(path.resolve("maps"));
         this.activeInstance = MinecraftServer.getInstanceManager().createInstanceContainer();
 
-        LobbyMapPredicate predicate = new LobbyMapPredicate();
-        MapEntry lobbyEntry = this.getEntries().stream().filter(predicate).findFirst().orElse(null);
-
-        if (lobbyEntry == null) {
-            throw new IllegalStateException("No lobby map found in the available maps");
+        MapEntry map = this.mapEntries.getFirst();
+        Optional<GameMap> loadedLobbyMap = fileHandler.load(map.getMapFile(), GameMap.class);
+        Check.argCondition(loadedLobbyMap.isEmpty(), "The map couldn't be loaded!");
+        this.activeMap = loadedLobbyMap.get();
+        this.activeInstance.setExplosionSupplier(new ExplosionCreator());
+        this.registerInstance(this.activeInstance, map);
+        if (this.activeMap.getSpawn() != null) {
+            activeInstance.loadChunk(this.activeMap.getSpawn());
         }
-
-        Optional<BaseMap> loadedLobbyMap = fileHandler.load(lobbyEntry.getMapFile(), BaseMap.class);
-        Check.argCondition(loadedLobbyMap.isEmpty(), "The lobby map couldn't be loaded!");
-        this.lobbyMap = loadedLobbyMap.get();
-        this.registerInstance(this.activeInstance, lobbyEntry);
-        if (this.lobbyMap.getSpawn() != null) {
-            activeInstance.loadChunk(this.lobbyMap.getSpawn());
-        }
-        this.activeMap = this.lobbyMap;
-
-        MapEntry gameEntry = this.getEntries().stream().filter(entry -> !predicate.test(entry))
-                        .skip(new Random().nextInt(0, this.getEntries().size() - 1)).findFirst().orElse(null);
-
-        Check.argCondition(gameEntry == null, "No game map found in the available maps");
-        Check.argCondition(!gameEntry.hasMapFile(), "The game map doesn't contain a map file!");
-        Optional<GameMap> loadedGameMap = fileHandler.load(gameEntry.getMapFile(), GameMap.class);
-        Check.argCondition(loadedGameMap.isEmpty(), "The game map couldn't be loaded!");
-        this.gameMap = loadedGameMap.get();
-        //((GameMap) this.gameMap).setMapEntry(gameEntry);
-
         MinecraftServer.getInstanceManager().registerInstance(this.activeInstance);
-        this.createGameMapContainer();
-    }
-
-    public void createGameMapContainer() {
-        if (this.gameMapInstance != null) return;
-        this.gameMapInstance = MinecraftServer.getInstanceManager().createInstanceContainer();
-        this.gameMapInstance.setExplosionSupplier(new ExplosionCreator());
-        this.gameMapInstance.enableAutoChunkLoad(true);
-        this.gameMapInstance.setTimeRate(0);
-        GameMap castetMap = ((GameMap) this.gameMap);
-        //MapEntry mapEntry = castetMap.getMapEntry();
-        // Check.argCondition(mapEntry == null, "The game map contains no map entry reference");
-        // AnvilLoader anvilLoader = new AnvilLoader(mapEntry.getDirectoryRoot());
-        //  this.gameMapInstance.setChunkLoader();
-
-        //this.gameArea.excludeBlocks(this.gameMapInstance);
-    }
-
-    public void switchInstanceHolding() {
-        this.activeMap = this.gameMap;
-        MinecraftServer.getInstanceManager().registerInstance(this.gameMapInstance);
-        this.activeInstance = this.gameMapInstance;
-        //this.gameArea.setInstanceSupplier(() -> this.gameMapInstance);
-    }
-
-    public void teleportPlayers(@NotNull List<Player> players, BooleanSupplier switchInstance) {
-      //  this.spawnArea.teleport(this.gameMapInstance, players, switchInstance);
-    }
-
-    public void resetSpawnArea() {
-        this.spawnArea.reset();
-    }
-
-    public void resetGameArea() {
-        this.gameArea.reset();
-    }
-
-    public void triggerSpawnPlacement() {
-
-        //this.spawnArea.triggerPlacement();
-    }
-
-    public void cleanupMapPlacement() {
-      //  this.gameArea.getTask().cancel();
-    }
-
-    public @NotNull Task triggerGamePlacement() {
-        return null;
     }
 
     public void loadGameChunks() {
-        GameMap givenMap = (GameMap) this.gameMap;
-        this.gameMapInstance.loadChunk(givenMap.getSpawnData().pos()).join();
+        GameMap givenMap = (GameMap) this.activeMap;
+        this.activeInstance.loadChunk(givenMap.getSpawn()).join();
     }
 
     @Override
     public void teleportToSpawn(@NotNull Player player, boolean instanceSet) {
-        if (this.activeMap instanceof GameMap) return;
+        if (instanceSet) {
+            player.setInstance(this.activeInstance, this.activeMap.getSpawn());
+            return;
+        }
         player.teleport(this.activeMap.getSpawn());
     }
 
@@ -132,14 +58,11 @@ public final class GameMapProvider extends AbstractMapProvider implements MapFil
         throw new UnsupportedOperationException("A game can't save a map");
     }
 
-    public @NotNull SpawnArea getSpawnArea() {
-        return this.spawnArea;
-    }
-
-    public @NotNull GameArea getGameArea() {
-        return this.gameArea;
-    }
-
+    /**
+     * Returns the current active map.
+     *
+     * @return the active map
+     */
     public @NotNull BaseMap getActiveMap() {
         return this.activeMap;
     }

--- a/game/src/main/java/net/theevilreaper/tamias/game/phase/LobbyPhase.java
+++ b/game/src/main/java/net/theevilreaper/tamias/game/phase/LobbyPhase.java
@@ -79,7 +79,7 @@ public final class LobbyPhase extends TimedPhase {
             }
             case 5 -> {
                 this.broadcastTime();
-                gameMapProvider.triggerSpawnPlacement();
+                //TODO: Add placement back
             }
             default -> {
                 // Nothing to do here

--- a/game/src/main/java/net/theevilreaper/tamias/game/phase/MapBuildPhase.java
+++ b/game/src/main/java/net/theevilreaper/tamias/game/phase/MapBuildPhase.java
@@ -5,22 +5,17 @@ import net.theevilreaper.xerus.api.phase.GamePhase;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import net.minestom.server.MinecraftServer;
-import net.minestom.server.entity.Player;
 import net.theevilreaper.tamias.common.event.AreaFinishBuildEvent;
 import net.theevilreaper.tamias.common.util.Messages;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import static net.minestom.server.MinecraftServer.getConnectionManager;
-
 /**
- * Tbe phase implementation handles each logic which should be executed during the period where the map builds up.
+ * The phase implementation handles each logic which should be executed during the period where the map builds up.
  * Its use only the {@link GamePhase} abstraction because the build process is not limited to a strict time duration.
  *
  * @author theEvilReaper
@@ -29,18 +24,14 @@ import static net.minestom.server.MinecraftServer.getConnectionManager;
  **/
 public final class MapBuildPhase extends GamePhase {
 
-    private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(MapBuildPhase.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(MapBuildPhase.class);
     private static final Component MAP_READY = Messages.withMini("<green>Map is ready!");
     private static final Component MAP_BUILDING = Messages.withMini("<green>Map is building up...");
 
-    private final VoidConsumer mapReferenceChange;
-    private final Consumer<List<Player>> teleportConsumer;
     private final Supplier<VoidConsumer> mapPlacementTaskTrigger;
     private VoidConsumer taskReset;
 
     public MapBuildPhase(
-            @NotNull VoidConsumer mapReferenceChange,
-            @NotNull Consumer<List<Player>> teleportConsumer,
             @NotNull Supplier<VoidConsumer> mapPlacementTaskTrigger
     ) {
         super("MapBuild");
@@ -49,16 +40,11 @@ public final class MapBuildPhase extends GamePhase {
                     .sendMessage(MAP_READY);
             finish();
         });
-        this.mapReferenceChange = mapReferenceChange;
-        this.teleportConsumer = teleportConsumer;
         this.mapPlacementTaskTrigger = mapPlacementTaskTrigger;
     }
 
     @Override
     protected void onStart() {
-        this.mapReferenceChange.apply();
-        List<Player> playerList = new ArrayList<>(getConnectionManager().getOnlinePlayers());
-        this.teleportConsumer.accept(playerList);
         MinecraftServer.getSchedulerManager().buildTask(() -> {
             Audience.audience(MinecraftServer.getConnectionManager().getOnlinePlayers())
                     .sendMessage(MAP_BUILDING);
@@ -70,8 +56,7 @@ public final class MapBuildPhase extends GamePhase {
 
     @Override
     public void finish() {
-        this.taskReset.apply();
         super.finish();
-        this.taskReset = null;
+        this.taskReset.apply();
     }
 }

--- a/game/src/main/java/net/theevilreaper/tamias/game/phase/playing/PostPlayingPhase.java
+++ b/game/src/main/java/net/theevilreaper/tamias/game/phase/playing/PostPlayingPhase.java
@@ -3,31 +3,24 @@ package net.theevilreaper.tamias.game.phase.playing;
 import net.theevilreaper.aves.util.functional.VoidConsumer;
 import net.theevilreaper.xerus.api.phase.TickDirection;
 import net.theevilreaper.xerus.api.phase.TimedPhase;
-import net.minestom.server.MinecraftServer;
-import net.minestom.server.entity.Player;
 import net.minestom.server.event.EventDispatcher;
 import net.theevilreaper.tamias.common.event.AreaCleanupEvent;
 import net.theevilreaper.tamias.common.event.AreaSpawnTriggerEvent;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.BooleanSupplier;
-import java.util.function.Consumer;
 
 public final class PostPlayingPhase extends TimedPhase {
 
     private final BooleanSupplier lastRoundCheck;
     private final VoidConsumer roundUpdateTrigger;
     private final VoidConsumer scoreboardReset;
-    private final Consumer<List<Player>> teleportConsumer;
 
     public PostPlayingPhase(
             @NotNull BooleanSupplier lastRoundCheck,
             @NotNull VoidConsumer roundUpdateTrigger,
-            @NotNull VoidConsumer scoreboardReset,
-            @NotNull Consumer<List<Player>> teleportConsumer
+            @NotNull VoidConsumer scoreboardReset
     ) {
         super("RoundEnd", ChronoUnit.SECONDS, 1);
         this.setPaused(false);
@@ -36,7 +29,6 @@ public final class PostPlayingPhase extends TimedPhase {
         this.lastRoundCheck = lastRoundCheck;
         this.roundUpdateTrigger = roundUpdateTrigger;
         this.scoreboardReset = scoreboardReset;
-        this.teleportConsumer = teleportConsumer;
     }
 
     @Override
@@ -60,8 +52,7 @@ public final class PostPlayingPhase extends TimedPhase {
             EventDispatcher.call(AreaSpawnTriggerEvent.empty());
         }
         if (this.getCurrentTicks() == 1) {
-            List<Player> onlinePlayers = new ArrayList<>(MinecraftServer.getConnectionManager().getOnlinePlayers());
-            this.teleportConsumer.accept(onlinePlayers);
+            //TODO: Teleport
         }
     }
 }

--- a/game/src/main/java/net/theevilreaper/tamias/game/phase/playing/PrePlayingPhase.java
+++ b/game/src/main/java/net/theevilreaper/tamias/game/phase/playing/PrePlayingPhase.java
@@ -1,6 +1,5 @@
 package net.theevilreaper.tamias.game.phase.playing;
 
-import net.theevilreaper.aves.map.BaseMap;
 import net.theevilreaper.aves.util.functional.VoidConsumer;
 import net.theevilreaper.xerus.api.phase.TickDirection;
 import net.theevilreaper.xerus.api.phase.TimedPhase;
@@ -9,7 +8,6 @@ import net.theevilreaper.xerus.api.team.TeamService;
 import net.kyori.adventure.text.Component;
 import net.minestom.server.entity.Player;
 import net.theevilreaper.tamias.common.config.GameConfig;
-import net.theevilreaper.tamias.common.map.GameMap;
 import net.theevilreaper.tamias.common.util.Tags;
 import net.theevilreaper.tamias.game.team.TeamHelper;
 import net.theevilreaper.tamias.game.util.EntityHelper;
@@ -17,10 +15,9 @@ import org.jetbrains.annotations.NotNull;
 
 import java.time.temporal.ChronoUnit;
 import java.util.function.BiConsumer;
-import java.util.function.Supplier;
 
 /**
- * The {@link PrePlayingPhase} deals each code logic which should be executed before the {@link PlayingPhase} begins.
+ * The {@link PrePlayingPhase} deals each code logic that should be executed before the {@link PlayingPhase} begins.
  * It reduces the complexity of the playing phase without dealing too much overhead.
  *
  * @author theEvilReaper
@@ -30,8 +27,6 @@ import java.util.function.Supplier;
 public final class PrePlayingPhase extends TimedPhase {
 
     private final TeamService<Team> teamService;
-    private final Supplier<BaseMap> gameMapSupplier;
-    private final VoidConsumer gamePreparation;
     private final BiConsumer<Player, Integer> itemConsumer;
     private final VoidConsumer staminaCreation;
 
@@ -39,14 +34,10 @@ public final class PrePlayingPhase extends TimedPhase {
      * Creates a new instance from the phase
      *
      * @param teamService     the service which provides access to the teams
-     * @param gameMapSupplier the supplier to access data from the map
-     * @param gamePreparation the logic which should be executed during due to this phase
      * @param itemConsumer     the consumer which triggers the item set logic
      */
     public PrePlayingPhase(
             @NotNull TeamService<Team> teamService,
-            @NotNull Supplier<BaseMap> gameMapSupplier,
-            @NotNull VoidConsumer gamePreparation,
             @NotNull BiConsumer<Player, Integer> itemConsumer,
             @NotNull VoidConsumer staminaCreation
     ) {
@@ -54,9 +45,7 @@ public final class PrePlayingPhase extends TimedPhase {
         this.setCurrentTicks(5);
         this.setTickDirection(TickDirection.DOWN);
         this.teamService = teamService;
-        this.gameMapSupplier = gameMapSupplier;
         this.itemConsumer = itemConsumer;
-        this.gamePreparation = gamePreparation;
         this.staminaCreation = staminaCreation;
     }
 
@@ -68,12 +57,7 @@ public final class PrePlayingPhase extends TimedPhase {
 
     @Override
     protected void onFinish() {
-        if (!(this.gameMapSupplier.get() instanceof GameMap gameMap)) {
-            throw new IllegalStateException("The game map is not a valid game map");
-        }
-        this.gamePreparation.apply();
         //Teleportation
-        TeamHelper.teleport(this.teamService, gameMap, this::updatePlayer);
         Team tntTeam = this.teamService.getTeams().get(GameConfig.TNT_ID);
         EntityHelper.switchToTNT(tntTeam.getPlayers().stream().findFirst().get());
         this.staminaCreation.apply();


### PR DESCRIPTION
The original approach was to use separate instances (worlds) for the lobby and the game. However, we decided to combine them into a single instance because the distinction between the lobby and game areas isn't based on a strong separating factor. Both areas are relatively small and can be combined to create a more seamless and cohesive map.