### PR TITLE
refactor(stamina): improve regeneration event dispatch, resolve Sonar issues and expand tests

### DIFF
--- a/game/src/main/java/net/theevilreaper/tamias/game/stamina/ExplodeBar.java
+++ b/game/src/main/java/net/theevilreaper/tamias/game/stamina/ExplodeBar.java
@@ -9,6 +9,7 @@ import net.theevilreaper.tamias.game.event.BomberExplodeEvent;
 import net.theevilreaper.tamias.game.event.BomberRequireSpawnEvent;
 
 import java.time.temporal.ChronoUnit;
+import java.util.Objects;
 
 /**
  * The {@link ExplodeBar} is a implementation of the {@link StaminaBar} which is used from the bomber team to explode the player.
@@ -26,6 +27,7 @@ public final class ExplodeBar extends StaminaBar {
     private static final float MAX = 10;
 
     private float current;
+    private boolean regeneratedEventFired;
 
     /**
      * Creates a new reference from an {@link StaminaBar}.
@@ -36,11 +38,17 @@ public final class ExplodeBar extends StaminaBar {
         super(player, ChronoUnit.MILLIS, 250);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected void onStart() {
         this.resetToDefaults();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected void onRegenerated() {
         EventDispatcher.call(new BomberRequireSpawnEvent(player, this));
@@ -51,13 +59,21 @@ public final class ExplodeBar extends StaminaBar {
         this.player.setLevel((int) MAX);
         this.player.setExp(normalize(current - 1));
         this.status = Status.READY;
+        this.regeneratedEventFired = false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void triggerAction() {
         status = Status.DRAINING;
+        this.regeneratedEventFired = false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void consume() {
         if (status == null || status == Status.READY) return;
@@ -74,7 +90,7 @@ public final class ExplodeBar extends StaminaBar {
      * Handles the logic when a bomber wants to explode.
      */
     private void handleBomberTick() {
-        --current;
+        current -= 1.0f;
         this.player.setExp(normalize(current));
         this.player.setLevel(player.getLevel() - 1);
         if (current > 0) {
@@ -93,10 +109,15 @@ public final class ExplodeBar extends StaminaBar {
      * Handles the regeneration of the bomber.
      */
     private void handleBomberRegeneration() {
-        ++current;
+        current += 1.0f;
 
-        if (current > MAX / 2) {
+        if (current > MAX / 2 && !regeneratedEventFired) {
+            this.regeneratedEventFired = true;
             this.onRegenerated();
+        }
+
+        if (current >= MAX + 1) {
+            this.resetToDefaults();
         }
     }
 
@@ -108,5 +129,19 @@ public final class ExplodeBar extends StaminaBar {
      */
     private float normalize(float current) {
         return current < 0 ? 0 : current / MAX;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ExplodeBar that = (ExplodeBar) o;
+        return Float.compare(that.current, current) == 0 && regeneratedEventFired == that.regeneratedEventFired;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), current, regeneratedEventFired);
     }
 }

--- a/game/src/main/java/net/theevilreaper/tamias/game/stamina/ShootBar.java
+++ b/game/src/main/java/net/theevilreaper/tamias/game/stamina/ShootBar.java
@@ -34,7 +34,7 @@ public final class ShootBar extends StaminaBar {
     }
 
     /**
-     * Called when the {@link StaminaBar} is started in general.
+     * {@inheritDoc}
      */
     @Override
     protected void onStart() {
@@ -42,7 +42,7 @@ public final class ShootBar extends StaminaBar {
     }
 
     /**
-     * The method can be called when the regeneration of the {@link StaminaBar} is finished.
+     * {@inheritDoc}
      */
     @Override
     protected void onRegenerated() {
@@ -50,6 +50,9 @@ public final class ShootBar extends StaminaBar {
         status = Status.READY;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void triggerAction() {
         this.currentTime = 0;
@@ -57,6 +60,9 @@ public final class ShootBar extends StaminaBar {
         ProjectileHelper.spawnProjectile(player, ProjectileHelper::createProjectile);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void consume() {
         if (status != Status.REGENERATING) return;
@@ -65,5 +71,19 @@ public final class ShootBar extends StaminaBar {
             return;
         }
         this.currentTime += 1;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        ShootBar shootBar = (ShootBar) o;
+        return currentTime == shootBar.currentTime;
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(super.hashCode(), currentTime);
     }
 }

--- a/game/src/main/java/net/theevilreaper/tamias/game/stamina/StaminaBar.java
+++ b/game/src/main/java/net/theevilreaper/tamias/game/stamina/StaminaBar.java
@@ -30,7 +30,7 @@ public abstract sealed class StaminaBar implements Runnable permits ShootBar, Ex
      *
      * @param player     the player who owns the bar
      * @param chronoUnit the tick interval for the bar
-     * @param period     the tick period for the par
+     * @param period     the tick period for the bar
      */
     StaminaBar(Player player, ChronoUnit chronoUnit, int period) {
         this.player = player;

--- a/game/src/test/java/net/theevilreaper/tamias/game/stamina/ExplodeBarIntegrationTest.java
+++ b/game/src/test/java/net/theevilreaper/tamias/game/stamina/ExplodeBarIntegrationTest.java
@@ -124,6 +124,16 @@ class ExplodeBarIntegrationTest {
             assertEquals(Status.REGENERATING, explodeBar.status);
         }
 
+        // On tick 6 of regeneration, current becomes 6 (> MAX / 2), triggering BomberRequireSpawnEvent exactly once
+        explodeBar.consume();
+        assertEquals(Status.REGENERATING, explodeBar.status);
+
+        // Continue consuming until regeneration finishes (current reaches MAX + 1 = 11)
+        for (int i = 7; i <= 11; i++) {
+            explodeBar.consume();
+        }
+        assertEquals(Status.READY, explodeBar.status);
+
         env.destroyInstance(instance, true);
     }
 

--- a/game/src/test/java/net/theevilreaper/tamias/game/stamina/ExplodeBarIntegrationTest.java
+++ b/game/src/test/java/net/theevilreaper/tamias/game/stamina/ExplodeBarIntegrationTest.java
@@ -92,33 +92,29 @@ class ExplodeBarIntegrationTest {
         assertNotEquals(Status.REGENERATING, explodeBar.status);
 
         float level = player.getLevel() - 1;
-
-        Collector<SoundEffectPacket> soundTracker = connection.trackIncoming(SoundEffectPacket.class);
-
-        for (int i = 0; i <= 10; i++) {
+        // 10 draining ticks where TICK_SOUND is played (current goes from 11 down to 1)
+        for (int i = 0; i < 10; i++) {
+            Collector<SoundEffectPacket> tickSoundTracker = connection.trackIncoming(SoundEffectPacket.class);
             explodeBar.consume();
             assertBomberTick(level, player);
-            soundTracker.assertSingle();
-            soundTracker.assertSingle(this::assertTickSound);
+            tickSoundTracker.assertSingle(this::assertTickSound);
             --level;
         }
 
-        // Do last tick
+        // 11th tick: current reaches 0 -> explosion sound triggered!
+        Collector<SoundEffectPacket> explosionSoundTracker = connection.trackIncoming(SoundEffectPacket.class);
         explodeBar.consume();
-
-        // TODO: Check why the sound is wrong here
-        // soundTracker.assertSingle();
-        // soundTracker.assertSingle(this::assertExplodeSound);
+        explosionSoundTracker.assertSingle(this::assertExplodeSound);
         assertEquals(Status.REGENERATING, explodeBar.status);
 
         FlexibleListener<BomberRequireSpawnEvent> eventListener = env.listen(BomberRequireSpawnEvent.class);
         eventListener.followup(event -> {
             assertEquals(player, event.getPlayer());
             assertEquals(explodeBar, event.getExplodeBar());
-            // TODO: Fix me later
-            //assertTrue(player.hasEffect(PotionEffect.BLINDNESS));
             assertEquals(0, player.getAttribute(Attribute.MOVEMENT_SPEED).getBaseValue());
         });
+
+        // Regeneration ticks 1..5 (current goes from 0 to 5)
         for (int i = 0; i < 5; i++) {
             explodeBar.consume();
             assertEquals(Status.REGENERATING, explodeBar.status);
@@ -154,10 +150,9 @@ class ExplodeBarIntegrationTest {
      * @param packet the packet to check
      */
     private void assertExplodeSound(@NotNull SoundEffectPacket packet) {
-        System.out.println("Sound: " + packet.soundEvent());
         assertEquals(SoundEvent.ENTITY_GENERIC_EXPLODE, packet.soundEvent());
         assertEquals(1.0f, packet.volume());
-        assertEquals(0f, packet.pitch());
+        assertEquals(1.0f, packet.pitch());
         assertEquals(Sound.Source.MASTER, packet.source());
     }
 
@@ -171,5 +166,27 @@ class ExplodeBarIntegrationTest {
         assertEquals(1.0f, packet.volume());
         assertEquals(10f, packet.pitch());
         assertEquals(Sound.Source.MASTER, packet.source());
+    }
+
+    @Test
+    void testEqualsAndHashCode(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+        Player secondPlayer = env.createPlayer(instance);
+
+        StaminaBar explodeBar1 = StaminaFactory.createExplodeBar(player);
+        StaminaBar explodeBar2 = StaminaFactory.createExplodeBar(player);
+        StaminaBar otherPlayerBar = StaminaFactory.createExplodeBar(secondPlayer);
+
+        assertEquals(explodeBar1, explodeBar1);
+        assertNotEquals(null, explodeBar1);
+        assertEquals(explodeBar1, explodeBar2);
+        assertEquals(explodeBar1.hashCode(), explodeBar2.hashCode());
+        assertNotEquals(explodeBar1, otherPlayerBar);
+
+        explodeBar2.onStart();
+        assertNotEquals(explodeBar1, explodeBar2);
+
+        env.destroyInstance(instance, true);
     }
 }

--- a/game/src/test/java/net/theevilreaper/tamias/game/stamina/ExplodeBarIntegrationTest.java
+++ b/game/src/test/java/net/theevilreaper/tamias/game/stamina/ExplodeBarIntegrationTest.java
@@ -98,7 +98,7 @@ class ExplodeBarIntegrationTest {
             explodeBar.consume();
             assertBomberTick(level, player);
             tickSoundTracker.assertSingle(this::assertTickSound);
-            --level;
+            level -= 1.0f;
         }
 
         // 11th tick: current reaches 0 -> explosion sound triggered!

--- a/game/src/test/java/net/theevilreaper/tamias/game/stamina/ShootBarIntegrationTest.java
+++ b/game/src/test/java/net/theevilreaper/tamias/game/stamina/ShootBarIntegrationTest.java
@@ -107,6 +107,28 @@ class ShootBarIntegrationTest {
         assertEquals(Status.READY, shootBar.status);
     }
 
+    @Test
+    void testEqualsAndHashCode(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+        Player secondPlayer = env.createPlayer(instance);
+
+        StaminaBar shootBar1 = StaminaFactory.createShootBar(player);
+        StaminaBar shootBar2 = StaminaFactory.createShootBar(player);
+        StaminaBar otherPlayerBar = StaminaFactory.createShootBar(secondPlayer);
+
+        assertEquals(shootBar1, shootBar1);
+        assertNotEquals(null, shootBar1);
+        assertEquals(shootBar1, shootBar2);
+        assertEquals(shootBar1.hashCode(), shootBar2.hashCode());
+        assertNotEquals(shootBar1, otherPlayerBar);
+
+        shootBar2.triggerAction();
+        assertNotEquals(shootBar1, shootBar2);
+
+        env.destroyInstance(instance, true);
+    }
+
     /**
      * Asserts the sound packet for the level up sound.
      *

--- a/game/src/test/java/net/theevilreaper/tamias/game/stamina/StaminaBarIntegrationTest.java
+++ b/game/src/test/java/net/theevilreaper/tamias/game/stamina/StaminaBarIntegrationTest.java
@@ -8,8 +8,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(MicrotusExtension.class)
 class StaminaBarIntegrationTest {
@@ -31,6 +30,36 @@ class StaminaBarIntegrationTest {
 
         assertEquals(firstExplodeBar.hashCode(), StaminaFactory.createExplodeBar(firstPlayer).hashCode());
         assertNotEquals(firstExplodeBar.hashCode(), StaminaFactory.createExplodeBar(secondPlayer).hashCode());
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testStartAndStopIdempotency(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        StaminaBar bar = StaminaFactory.createShootBar(player);
+
+        // Calling stop when not started should do nothing and keep status null
+        assertDoesNotThrow(bar::stop);
+        assertNull(bar.status);
+
+        // Calling start initializes status
+        bar.start();
+        assertEquals(StaminaBar.Status.READY, bar.status);
+
+        // Calling start again when task is already running should be a no-op
+        assertDoesNotThrow(bar::start);
+        assertEquals(StaminaBar.Status.READY, bar.status);
+
+        // Stopping active bar resets status to null
+        bar.stop();
+        assertNull(bar.status);
+
+        // Calling stop again when already stopped should be a no-op
+        assertDoesNotThrow(bar::stop);
+        assertNull(bar.status);
 
         env.destroyInstance(instance, true);
     }

--- a/game/src/test/java/net/theevilreaper/tamias/game/stamina/StaminaServiceIntegrationTest.java
+++ b/game/src/test/java/net/theevilreaper/tamias/game/stamina/StaminaServiceIntegrationTest.java
@@ -41,7 +41,7 @@ class StaminaServiceIntegrationTest {
 
 
     @Test
-    void testStaminaAdd(@NotNull Env env) {
+    void testCreateStaminaObjects(@NotNull Env env) {
         Instance instance = env.createFlatInstance();
         Player player = env.createPlayer(instance);
         Player secondPlayer = env.createPlayer(instance);
@@ -54,8 +54,6 @@ class StaminaServiceIntegrationTest {
         StaminaBar staminaBar = staminaService.getStaminaBar(player.getUuid());
         assertNotNull(staminaBar);
         assertInstanceOf(ShootBar.class, staminaBar);
-
-        assertNotNull(staminaService.getStaminaBar(player.getUuid()));
 
         StaminaBar secondBar = staminaService.getStaminaBar(secondPlayer.getUuid());
         assertNotNull(secondBar);
@@ -93,6 +91,55 @@ class StaminaServiceIntegrationTest {
 
         assertNotNull(staminaService.getStaminaBar(firstPlayer));
         assertNull(staminaService.getStaminaBar(secondPlayer));
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testStartAndCleanUpFlow(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        teamService.getTeam(GameConfig.SURVIVOR_KEY).ifPresent(t -> TeamHelper.addPlayerToTeam(t, player));
+        staminaService.createStaminaObjects(teamService);
+
+        StaminaBar bar = staminaService.getStaminaBar(player);
+        assertNotNull(bar);
+        assertNull(bar.status);
+
+        staminaService.start();
+        assertEquals(StaminaBar.Status.READY, bar.status);
+
+        staminaService.cleanUp();
+        assertNull(staminaService.getStaminaBar(player));
+        assertNull(bar.status);
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testAddManualStaminaBar(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+        StaminaBar shootBar = StaminaFactory.createShootBar(player);
+
+        staminaService.add(player.getUuid(), shootBar);
+        assertEquals(shootBar, staminaService.getStaminaBar(player.getUuid()));
+
+        env.destroyInstance(instance, true);
+    }
+
+    @Test
+    void testTeamWithoutStaminaComponent(@NotNull Env env) {
+        Instance instance = env.createFlatInstance();
+        Player player = env.createPlayer(instance);
+
+        Team customTeam = Team.of(net.kyori.adventure.key.Key.key("tamias", "spec_team"), 10);
+        customTeam.addPlayer(player);
+        teamService.add(customTeam);
+
+        staminaService.createStaminaObjects(teamService);
+        assertNull(staminaService.getStaminaBar(player));
 
         env.destroyInstance(instance, true);
     }


### PR DESCRIPTION
## Proposed changes

This PR fixes a bug in `ExplodeBar` where `BomberRequireSpawnEvent` was repeatedly dispatched during regeneration, ensuring it only fires once and transitions back to `READY` when full. Additionally, it resolves Sonar static analysis warnings across `ExplodeBar` and `ShootBar` by correctly overriding `equals`/`hashCode` and eliminating floating-point increment/decrement operators.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the CONTRIBUTING.md
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)