### PR TITLE
chore(ci): adopt shared workflows and central Renovate preset

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,17 @@
+name: PR Lint
+
+# Conventional Commits on the PR title and every commit on the branch.
+# release-please parses those commit types to decide the version bump and to
+# build the changelog - a non-conventional commit silently produces neither.
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  lint:
+    uses: OneLiteFeatherNET/workflows/.github/workflows/pr-lint.yml@v2.8.1
+    secrets: inherit

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,3 +32,30 @@ jobs:
       java-version: "25"
       publish-task: "publish"
     secrets: inherit
+  sbom:
+    name: Attach SBOM to release
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+
+      - name: Generate CycloneDX SBOM
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: cyclonedx
+          output: bom.json
+          exit-code: '0'
+
+      - name: Attach SBOM to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-please.outputs.tag_name }}
+        run: gh release upload "$TAG" bom.json --clobber

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,55 @@
+name: Security
+
+# Trivy vulnerability gate plus a CycloneDX SBOM of the repository. Self-contained
+# on purpose: it needs no build tool and no registry credentials, so it is the
+# baseline security gate for every repository regardless of language.
+on:
+  pull_request:
+  push:
+    branches: [develop]
+  schedule:
+    - cron: "25 3 * * 1"
+  workflow_dispatch:
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  trivy:
+    name: Trivy scan
+    uses: OneLiteFeatherNET/workflows/.github/workflows/security-scan.yml@v2.8.1
+    with:
+      scan-type: "fs"
+      scanners: "vuln,secret"
+      severity: "CRITICAL,HIGH"
+      # Report-only for now, so adopting this does not turn CI red on day one.
+      fail-on-findings: false
+      upload-sarif: true
+    secrets: inherit
+
+  sbom:
+    name: CycloneDX SBOM
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Generate SBOM
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: cyclonedx
+          output: bom.json
+          # An SBOM is an inventory, not a finding list - never fail on it.
+          exit-code: '0'
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-cyclonedx
+          path: bom.json
+          if-no-files-found: error
+          retention-days: 90

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 allprojects {
-    version = (version as String).substringBefore('#').trim()
+    version = "0.0.1" // x-release-please-version
 }

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,3 @@
+export default {
+  extends: ['@commitlint/config-conventional'],
+};

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
 ### Project settings
-version = 0.0.1 # x-release-please-version
 group = net.onelitefeather

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,10 @@
       "release-type": "java",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
-        { "type": "generic", "path": "gradle.properties" }
+        {
+          "type": "generic",
+          "path": "build.gradle.kts"
+        }
       ]
     }
   }

--- a/renovate.json
+++ b/renovate.json
@@ -1,12 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "github>OneLiteFeatherNET/renovate:default(OneLiteFeatherNET/tamias-maintainers)"
   ],
-  "labels": [
-    "Renovate"
-  ],
-  "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchUpdateTypes": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>OneLiteFeatherNET/renovate:default(OneLiteFeatherNET/tamias-maintainers)"
+    "github>OneLiteFeatherNET/renovate:default(OneLiteFeatherNET/tamias-maintainers)",
+    "github>OneLiteFeatherNET/renovate:minestom"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## What

Brings this repository onto the OneLiteFeather standard CI, release and dependency setup.

**CI, security and dependencies**

- renovate.json -> central preset (tamias-maintainers)
- security.yml (Trivy + CycloneDX SBOM)

**Release automation and PR hygiene**

- pr-lint.yml
- commitlint.config.mjs
- SBOM job appended to release-please.yml

**Version anchoring and Renovate presets**

- renovate flavor restored: minestom
- version moved out of gradle.properties into build.gradle.kts
- removed the now-unused version from gradle.properties
- extra-files now points at build.gradle.kts

## Why

One shared setup per concern instead of a hand-maintained copy per repository:

- **Reusable workflows** (`OneLiteFeatherNET/workflows`) are pinned to a full SemVer tag, so a fix
  in the shared catalogue reaches this repository through a Renovate PR.
- **Central Renovate preset** brings the shared schedule, automerge and labelling rules and assigns
  the maintainer team as reviewer, instead of a per-repository config that drifts.
- **Security gate**: Trivy scans for vulnerabilities and secrets and reports into GitHub code
  scanning, plus a CycloneDX SBOM on every run. Report-only, so adopting it does not turn CI red on
  day one.
- **Release Please in simple mode** turns Conventional Commits into a release PR; merging it tags
  the version and cuts the release. Simple mode deliberately does not rewrite language version
  files, which keeps this change limited to release plumbing.
- **A CycloneDX SBOM is attached to every GitHub release**, so each shipped version carries its own
  dependency inventory.
- **The Renovate platform preset** (`:minestom` / `:paper`) is what teaches Renovate the
  date-based Minestom scheme and Paper's `X.Y.Z-<mc-version>` scheme; without it those two get
  parsed as plain SemVer and updated wrongly.
- **The version lives in `build.gradle.kts` behind `// x-release-please-version`**, so a release
  changes exactly one line in one file instead of a properties file the build has to parse.
- **PR linting** enforces Conventional Commits on the PR title and on every commit - without it
  release-please silently fails to bump the version or drops the commit from the changelog.

Everything a release needs is chained into the release-please workflow run on purpose: release-please
tags with `GITHUB_TOKEN`, and a tag pushed that way does **not** start a separate
`on: push: tags` workflow.